### PR TITLE
Implement retrieving GuiSettings

### DIFF
--- a/tesla/src/lib.rs
+++ b/tesla/src/lib.rs
@@ -12,6 +12,7 @@ const ENDPOINT_GET_VEHICLES: &str = "vehicles";
 const ENDPOINT_GET_VEHICLE: &str = "vehicles/{}";
 
 const VEHICLE_CHARGE_STATE: &str = "data_request/charge_state";
+const VEHICLE_GUI_SETTINGS: &str = "data_request/gui_settings";
 const VEHICLE_DATA: &str = "vehicle_data";
 const VEHICLE_COMMAND_WAKE: &str = "wake_up";
 
@@ -122,7 +123,15 @@ impl VehicleClient {
             .send()?
             .json()?;
 
-        println!("Resp: {:?}", resp);
+        Ok(resp.into_response())
+    }
+
+    pub fn get_gui_settings(&self) -> Result<GuiSettings, reqwest::Error> {
+        let url = endpoint_url!(self, VEHICLE_GUI_SETTINGS);
+
+        let resp: Response<GuiSettings> = self.tesla_client.client.get(url)
+            .send()?
+            .json()?;
 
         Ok(resp.into_response())
     }

--- a/tesla/src/models.rs
+++ b/tesla/src/models.rs
@@ -55,6 +55,14 @@ pub struct FullVehicleData {
     pub vehicle_state: VehicleState,
     pub drive_state: DriveState,
     pub climate_state: ClimateState,
+    pub gui_settings: GuiSettings,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GuiSettings {
+    pub gui_charge_rate_units: String,
+    pub gui_distance_units: String,
+    pub gui_temperature_units: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This allows retrieving some settings which can be used to determine how certain data (e.g. the expected range) can be represented to the user because the user may expect metric instead of the default imperial values.

Also remove debug printf() while here.